### PR TITLE
remove retry / redo option

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -15,7 +15,8 @@ let config = {
     primaryColor: 'steelblue',  // primary CSS color
     secondaryColor: '#f2f2f2',  // secondary CSS color
     textColor: 'black',         // text color of some elements
-    locale: null                // language of the user interface (auto-detect per default)
+    locale: null,               // language of the user interface (auto-detect per default)
+    enableRetry: true           // allow the user to resubmit answers
 };
 
 quizdown.init(config);

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -33,7 +33,9 @@
     $: allVisited = quiz.allVisited;
 
     //let game = new Linear(quiz);
-
+    
+    let enableRetry = quiz.config.enableRetry;
+    
     registerLanguages(quiz.config.locale);
     registerIcons();
 
@@ -115,15 +117,18 @@
                             </div>
                         {/if}
                     </svelte:fragment>
-
-                    <Button
-                        slot="right"
-                        title="{$_('reset')}"
-                        buttonAction="{() => {
-                            reloaded = !reloaded;
-                            quiz.reset();
-                        }}"><Icon name="redo" /></Button
-                    >
+                    <svelte:fragment slot="right">
+                        {#if enableRetry}
+                            <Button
+                                slot="right"
+                                title="{$_('reset')}"
+                                buttonAction="{() => {
+                                    reloaded = !reloaded;
+                                    quiz.reset();
+                                }}"><Icon name="redo" /></Button
+                            >
+                        {/if}
+                    </svelte:fragment>
                 </Row>
 
                 <Credits />

--- a/src/components/ResultsView.svelte
+++ b/src/components/ResultsView.svelte
@@ -35,7 +35,12 @@
 
         <ol>
             {#each quiz.questions as question, i}
-                <li class="top-list-item" on:click="{() => quiz.jump(i)}">
+                <li class="top-list-item" on:click="{() => {
+                    if(quiz.config.enableRetry) {
+                        quiz.jump(i);
+                    }
+                    }
+                    }">
                     <span class="list-question">
                         {emojis[+question.solved]}
                         {@html question.text}

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,7 @@ const toRename = {
     primary_color: 'primaryColor',
     secondary_color: 'secondaryColor',
     text_color: 'textColor',
+    enable_retry: 'enableRetry'
 };
 
 export class Config {
@@ -26,6 +27,7 @@ export class Config {
     secondaryColor: string;
     textColor: string;
     locale: 'de' | 'en' | 'es' | 'fr' | null;
+    enableRetry: boolean;
 
     constructor(options: Config | object) {
         // handle <=v0.3.0 snake_case options for backwards compatibility
@@ -40,6 +42,7 @@ export class Config {
         this.secondaryColor = get(options['secondaryColor'], '#f2f2f2');
         this.textColor = get(options['textColor'], 'black');
         this.locale = get(options['locale'], null);
+        this.enableRetry = get(options['enableRetry'],true);
     }
 }
 


### PR DESCRIPTION
To address #45, this PR does the following:

* adds documentation for enableRetry option
* adds enableRetry option to quiz config
* optionally removes the retry button from the svelte app
* optionally disables the onclick event for questions in the review svelte

@bonartm